### PR TITLE
add function simplelogin

### DIFF
--- a/ManagementSystem/settings.py
+++ b/ManagementSystem/settings.py
@@ -27,7 +27,7 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
-
+LOGIN_URL = 'login/'
 # Application definition
 
 INSTALLED_APPS = (
@@ -69,6 +69,8 @@ TEMPLATES = [
     },
 ]
 
+AUTH_USER_MODEL = 'system.CustomUser'
+
 WSGI_APPLICATION = 'ManagementSystem.wsgi.application'
 
 
@@ -86,9 +88,9 @@ DATABASES = {
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'ja'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Asia/Tokyo'
 
 USE_I18N = True
 

--- a/ManagementSystem/settings.py
+++ b/ManagementSystem/settings.py
@@ -27,8 +27,14 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
-LOGIN_URL = 'login/'
+LOGIN_URL = '/system/login/'
 # Application definition
+LOGIN_REDIRECT_URL = '/system/'
+ALLOWED_EXEMPT_URLS = (
+    r'^admin/',
+    r'^system/$'
+)
+
 
 INSTALLED_APPS = (
     'django.contrib.admin',
@@ -49,6 +55,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'system.middleware.loginMiddleware.LoginMiddleware',
 )
 
 ROOT_URLCONF = 'ManagementSystem.urls'

--- a/ManagementSystem/urls.py
+++ b/ManagementSystem/urls.py
@@ -14,6 +14,7 @@ Including another URLconf
 """
 from django.conf.urls import include, url
 from django.contrib import admin
+from system.controllers import loginView
 
 urlpatterns = [
     url(r'^system/', include('system.urls')),

--- a/ManagementSystem/urls.py
+++ b/ManagementSystem/urls.py
@@ -14,7 +14,6 @@ Including another URLconf
 """
 from django.conf.urls import include, url
 from django.contrib import admin
-from system.controllers import loginView
 
 urlpatterns = [
     url(r'^system/', include('system.urls')),

--- a/system/admin.py
+++ b/system/admin.py
@@ -1,17 +1,10 @@
 from django.contrib import admin
-from .models import User, Equipment, Search, Reserved, Request, Vote, Log
+from .models import *
 
-admin.site.register(User)
+admin.site.register(CustomUser)
 admin.site.register(Equipment)
 admin.site.register(Search)
 admin.site.register(Reserved)
 admin.site.register(Request)
 admin.site.register(Vote)
 admin.site.register(Log)
-
-
-
-
-
-
-

--- a/system/admin.py
+++ b/system/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import *
+from .models import CustomUser, Equipment, Search, Reserved, Request, Vote, Log
 
 admin.site.register(CustomUser)
 admin.site.register(Equipment)

--- a/system/controllers/loginView.py
+++ b/system/controllers/loginView.py
@@ -1,0 +1,14 @@
+from django.shortcuts import render_to_response
+from django.template import RequestContext
+
+
+def login(request):
+    context = RequestContext(request,
+                             {'request': request,
+                              'user': request.user})
+    print(request.user.is_authenticated())
+    if request.user.is_authenticated():
+        # print(request.user.objects.all())
+        print(request.user.pk)
+    return render_to_response('login.html',
+                              context_instance=context)

--- a/system/controllers/topView.py
+++ b/system/controllers/topView.py
@@ -1,11 +1,14 @@
 from django.shortcuts import render_to_response
 from system.models import Equipment, Reserved
+from django.contrib.auth.decorators import *
 
+
+@login_required
 def topView(request):
     equipment_list = Equipment.objects.all()
     for equipment in equipment_list:
         equipment.reserved_num = Reserved.objects.filter(equipment=equipment).count()
         print(equipment.reserved_num)
-    return render_to_response('topView.html',{
+    return render_to_response('topView.html', {
         'equipment_list': equipment_list,
-        })
+    })

--- a/system/middleware/__init__.py
+++ b/system/middleware/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'Owner'

--- a/system/middleware/loginMiddleware.py
+++ b/system/middleware/loginMiddleware.py
@@ -29,13 +29,6 @@ class LoginMiddleware:
     """
 
     def process_request(self, request):
-        assert hasattr(request, 'user'), "ログイン要求ミドルウェア\
-はユーザ認証ミドルウェアのインストールを要求します。MIDDLEWARE_CLASSES を\
-編集して、'django.contrib.auth.middlware.AuthenticationMiddleware' を\
-追加してください。動作しない場合、 TEMPLATE_CONTEXT_PROCESSORS 設定が\
-'django.core.context_processors.auth' に読み込まれていることを\
-確認して下さい。"
-
         if not request.user.is_authenticated():
             path = request.path_info.lstrip('/')
             if not any(m.match(path) for m in EXEMPT_URLS):
@@ -45,7 +38,5 @@ class LoginMiddleware:
             path = request.path_info.lstrip('/')
             if not any(m.match(path) for m in ALLOWED_EXEMPT_URLS):
                 print('not allowed')
-                print(request.user.is_valid)
             else:
                 print('allowed')
-                print(request.user.is_valid)

--- a/system/middleware/loginMiddleware.py
+++ b/system/middleware/loginMiddleware.py
@@ -1,0 +1,51 @@
+from django.http import HttpResponseRedirect
+from django.conf import settings
+from re import compile
+
+EXEMPT_URLS = [compile(settings.LOGIN_URL.lstrip('/'))]
+ALLOWED_EXEMPT_URLS = None
+if hasattr(settings, 'LOGIN_EXEMPT_URLS'):
+    EXEMPT_URLS += [compile(expr) for expr in settings.LOGIN_EXEMPT_URLS]
+if hasattr(settings, 'ALLOWED_EXEMPT_URLS'):
+    ALLOWED_EXEMPT_URLS = [compile(expr) for expr in settings.ALLOWED_EXEMPT_URLS]
+
+
+class LoginMiddleware:
+    """
+    このミドルウェアは以下のサイトを基に作られています。
+    http://hateda.hatenadiary.jp/entry/2014/01/27/151615
+    よろしければ参考にどうぞ
+
+
+    LOGIN_URL 以外のページでユーザ認証を要求するミドルウェア。
+    ユーザ認証を免除するページは、 LOGIN_EXEMPT_URLS に正規表現で指定する
+    必要がある。（これを urls.py にコピーすることもできる）
+    ログイン要求ミドルウェアとコンテキストプロセッサーのテンプレートが
+    読み込まれる。読み込まれなかった場合、エラーが発生するかもれない。
+
+    追加機能として、ALLOED_EXMPT_URLS以外のページでユーザー認証を判定できる。
+    Userモデルのis_validが有効でない場合すなわち登録要求はしているが管理者が有効にしていない場合は
+    ALLOWED_URLに飛ばすことである。
+    """
+
+    def process_request(self, request):
+        assert hasattr(request, 'user'), "ログイン要求ミドルウェア\
+はユーザ認証ミドルウェアのインストールを要求します。MIDDLEWARE_CLASSES を\
+編集して、'django.contrib.auth.middlware.AuthenticationMiddleware' を\
+追加してください。動作しない場合、 TEMPLATE_CONTEXT_PROCESSORS 設定が\
+'django.core.context_processors.auth' に読み込まれていることを\
+確認して下さい。"
+
+        if not request.user.is_authenticated():
+            path = request.path_info.lstrip('/')
+            if not any(m.match(path) for m in EXEMPT_URLS):
+                return HttpResponseRedirect(settings.LOGIN_URL)
+        elif not request.user.is_valid:
+            # 許可されていないユーザーかどうかを判定する
+            path = request.path_info.lstrip('/')
+            if not any(m.match(path) for m in ALLOWED_EXEMPT_URLS):
+                print('not allowed')
+                print(request.user.is_valid)
+            else:
+                print('allowed')
+                print(request.user.is_valid)

--- a/system/models.py
+++ b/system/models.py
@@ -1,8 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import AbstractUser
 
-# [ ユーザーテーブル ]
-# (id), ユーザー名, googleユーザーID
+
 class CustomUser(AbstractUser):
     is_valid = models.BooleanField(default=False)
 

--- a/system/models.py
+++ b/system/models.py
@@ -1,25 +1,23 @@
 from django.db import models
-from django.utils import timezone
+from django.contrib.auth.models import AbstractUser
 
 # [ ユーザーテーブル ]
 # (id), ユーザー名, googleユーザーID
-class User(models.Model):
-    user_name = models.CharField(max_length=20)
-    user_id = models.CharField(max_length=20)
+class CustomUser(AbstractUser):
+    is_valid = models.BooleanField(default=False)
 
-    def __str__(self):
-        return self.user_name
 
 # [ 備品テーブル ]
 # (id), 備品名, 借用者(ユーザーid(外部キー)), 借りた日, 貸出し回数
 class Equipment(models.Model):
     equipment_name = models.CharField(max_length=50)
-    borrower = models.ForeignKey(User)
-    borrowed_date = models.DateField(default=timezone.now())
+    borrower = models.ForeignKey(CustomUser)
+    borrowed_date = models.DateField(auto_now=True)
     Lend_count = models.IntegerField(default=0)
 
     def __str__(self):
         return self.equipment_name
+
 
 # [ 検索用テーブル ]
 # 備品id(外部キー), 検索用メタデータ
@@ -30,37 +28,44 @@ class Search(models.Model):
     def __str__(self):
         return str(self.equipment_name) + ": " + self.meta_data
 
+
 # [ 予約テーブル ]
 # 備品id(外部キー), ユーザーid(外部キー), 予約日
 class Reserved(models.Model):
     equipment = models.ForeignKey(Equipment)
-    user = models.ForeignKey(User)
-    reserved = models.DateField(default=timezone.now())
+    user = models.ForeignKey(CustomUser)
+    reserved = models.DateField(auto_now=True)
 
     def __str__(self):
         return str(self.equipment)
+
 
 # [ リクエストテーブル ]
 # (id), 商品名, AmazonURL, 一言コメント
 class Request(models.Model):
     request_name = models.CharField(max_length=50)
     url = models.CharField(max_length=100)
+
     def __str__(self):
         return self.request_name
+
 
 # [ リクエストサブテーブル(投票集計) ]
 # リクエストid(外部キー), ユーザーid(外部キー)
 class Vote(models.Model):
     request = models.ForeignKey(Request)
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(CustomUser)
+
     def __str__(self):
         return str(self.request)
+
+
 # [ 貸出しログ ]
 # 借りた人(ユーザーid(外部キー)), 借りた物(備品id(外部キー)), 借りた日付
 class Log(models.Model):
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(CustomUser)
     equipment = models.ForeignKey(Equipment)
-    borrowed_date = models.DateField(default=timezone.now())
+    borrowed_date = models.DateField(auto_now=True)
+
     def __str__(self):
         return str(self.user)
-

--- a/system/templates/login.html
+++ b/system/templates/login.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title></title>
+</head>
+<body>
+{% if form.errors %}
+    <p>Your username and password didn't match. Please try again.</p>
+{% endif %}
+
+<form method="post" action="{% url 'django.contrib.auth.views.login' %}">
+    {% csrf_token %}
+    <table>
+        <tr>
+            <td>{{ form.username.label_tag }}</td>
+            <td>{{ form.username }}</td>
+        </tr>
+        <tr>
+            <td>{{ form.password.label_tag }}</td>
+            <td>{{ form.password }}</td>
+        </tr>
+    </table>
+
+    <input type="submit" value="login"/>
+    <input type="hidden" name="next" value="{{ next }}"/>
+</form>
+</body>
+</html>

--- a/system/templates/logout.html
+++ b/system/templates/logout.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title></title>
+</head>
+<body>
+{% block title %}ログアウト{% endblock title %}
+
+<h3 class="page-header">ログアウトしました</h3>
+</body>
+</html>

--- a/system/urls.py
+++ b/system/urls.py
@@ -9,4 +9,8 @@ urlpatterns = [
     url(r'^mypage/$', mypageView.mypageView),
     url(r'^log/$', logView.logView),
     url(r'^request/$', requestView.requestView),
+    url(r'^login/$', 'django.contrib.auth.views.login',
+        {'template_name': 'login.html'}),
+    url(r'^logout/$', 'django.contrib.auth.views.logout',
+        {'template_name': 'logout.html'}),
 ]


### PR DESCRIPTION
Djangoの機能を用いてシンプルなログイン認証を作成しました。それに伴いUserモデルの変更をしています。
具体的にはAbstractUserを継承し、フィールドにis_validを追加しました。また、settingにAUTH_USER_MODEL = 'system.CustomUser'と追記することで、djangoのUserモデルを作成したCustomUserモデルに置き換えてdjangoの認証機能を有効利用できます。
これによって、Viewページに@login_requireとつけるとログインしていなければアクセスできないようにすることができたり、request.userなどでログインしているUserの情報を取得できます。
@login_requireやrequest.userでユーザーの情報を取得できる機能はgoogle_outhでも使うことができるので、どちらのログイン機能を使ってもmypageやtoppageには影響はないと思います。

ユーザーの登録に関してですが、それはGoogle認証かそれとも今回実装したものを使うかを確定するまでは、実装しない予定です。

このログイン機能で、恐らく問題ないのですが少しだけ冗長な点があってログインしなければアクセスできないようにする機能に関しては、すべてのViewの関数に@login_requireをつけなければいけないので、少し面倒ですなので、これを緩和するような機能を木曜日までにはつけようと思います。
