### PR TITLE
Fix isbn register

### DIFF
--- a/system/controllers/addEquipmentView.py
+++ b/system/controllers/addEquipmentView.py
@@ -21,11 +21,16 @@ def addEquipmentView(request):
     author = request.GET.get("author")
     publisher = request.GET.get("publisher")
     isbn = request.GET.get("isbn")
-    if request.GET and (
+    if isbn:
+        item = RakutenBooks.getItem(isbn)
+        if item:
+            items.append(item.createEquipment())
+        else:
+            error = "検索結果が見つかりませんでした。"
+    elif request.GET and (
             keyword or
             author or
-            publisher or
-            isbn):
+            publisher):
         rakutenApi = RakutenBooks(
                 title=keyword,
                 author=author,

--- a/system/controllers/rakuten.py
+++ b/system/controllers/rakuten.py
@@ -1,6 +1,9 @@
 # coding -*- utf-8 -*-
 import json
 import requests
+from xml.etree import ElementTree
+import re
+
 from io import StringIO
 from system.models import Equipment
 
@@ -12,6 +15,7 @@ class Rakuten():
 
     __APPLICATION_ID = "1011546524580691339"
     searchResult = None
+    isbn_url = "http://iss.ndl.go.jp/api/sru?operation=searchRetrieve&query=isbn={isbn}"
 
     def __init__(self, **query):
         self._queryUrl = self._createQueryUrl(**query)
@@ -53,16 +57,20 @@ class Item():
         self.item = item
 
     def get(self, info):
-        return self.item[info]
+        return self.item.get(info)
 
     def createEquipment(self):
+        product_url = self.get("itemUrl")
+        equipment_name = self.get("title")
+        product_url = product_url if product_url else\
+                "https://www.google.co.jp/search?q=" + equipment_name
         return Equipment(
-                equipment_name=self.get("title"),
+                equipment_name=equipment_name,
                 author=self.get("author"),
                 company=self.get("publisherName"),
                 price=self.get("itemPrice"),
                 isbn=self.get("isbn"),
-                product_url=self.get("itemUrl"),
+                product_url=product_url,
                 image_url=self.get("mediumImageUrl")
                 )
 
@@ -80,11 +88,26 @@ class RakutenBooks(Rakuten):
 
     @staticmethod
     def getItem(isbn):
-        rakuten = RakutenBooks(isbn=isbn)
-        rakuten.search()
-        items = rakuten.getItems()
-        return items[0] if items else None
+        # rakuten = RakutenBooks(isbn=isbn)
+        # rakuten.search()
+        # items = rakuten.getItems()
+        # return items[0] if items else None
+        return RakutenBooks.nationalDietLibraryGetItem(isbn)
 
+    @staticmethod
+    def nationalDietLibraryGetItem(isbn):
+        isbn = re.sub(r"\D", "", str(isbn))
+        tree = ElementTree.fromstring(requests.get(Rakuten.isbn_url.format(isbn=isbn)).text)
+        recordData = tree.find("{http://www.loc.gov/zing/srw/}records").find("{http://www.loc.gov/zing/srw/}record").find("{http://www.loc.gov/zing/srw/}recordData")
+        tree = ElementTree.fromstring(recordData.text)
+        dc = "{http://purl.org/dc/elements/1.1/}"
+        return Item({
+            "title": tree.find(dc + "title").text,
+            "author": tree.find(dc + "creator").text,
+            "publisherName": tree.find(dc + "publisher").text,
+            "isbn": isbn,
+            "itemPrice": 0,
+            })
 
 class RakutenIchiba(Rakuten):
     """このクラスは、楽天商品検索apiを使うためのクラスです。

--- a/system/models.py
+++ b/system/models.py
@@ -1,4 +1,4 @@
-from django.db import models
+fom django.db import models
 from django.contrib.auth.models import AbstractUser
 
 

--- a/system/models.py
+++ b/system/models.py
@@ -1,4 +1,4 @@
-fom django.db import models
+from django.db import models
 from django.contrib.auth.models import AbstractUser
 
 


### PR DESCRIPTION
isbnでちゃんと備品登録できるようになりました
isbn検索には国立国会図書館api使ってます。そのため、登録されるものは、タイトル、著者、出版社のみです。
詳細用のurlにはgoogleの検索結果を張っておきました。
